### PR TITLE
Be able to run CLI commands with API keys

### DIFF
--- a/cli/internal/accesstoken/api_key.go
+++ b/cli/internal/accesstoken/api_key.go
@@ -1,0 +1,8 @@
+package accesstoken
+
+import "os"
+
+// GetAPIKeyEnvVar returns the value of the LLMARINER_API_KEY environment variable.
+func GetAPIKeyEnvVar() string {
+	return os.Getenv("LLMARINER_API_KEY")
+}

--- a/cli/internal/http/http.go
+++ b/cli/internal/http/http.go
@@ -135,7 +135,7 @@ func extractErrorMessage(body io.ReadCloser) string {
 
 // addHeaders adds headers to the request.
 func (c *Client) addHeaders(req *http.Request) {
-	req.Header.Add("Authorization", "Bearer "+c.env.Token.AccessToken)
+	req.Header.Add("Authorization", "Bearer "+c.env.AccessToken())
 	if id := c.env.Config.Context.OrganizationID; id != "" {
 		req.Header.Add("Openai-Organization", id)
 	}

--- a/cli/internal/k8s/k8s.go
+++ b/cli/internal/k8s/k8s.go
@@ -17,6 +17,6 @@ func NewClient(env *runtime.Env, clusterID string) (kubernetes.Interface, error)
 func newConfig(env *runtime.Env, clusterID string) *rest.Config {
 	return &rest.Config{
 		Host:        fmt.Sprintf("%s/sessions/%s", env.Config.EndpointURL, clusterID),
-		BearerToken: env.Token.AccessToken,
+		BearerToken: env.AccessToken(),
 	}
 }

--- a/cli/internal/runtime/env.go
+++ b/cli/internal/runtime/env.go
@@ -14,6 +14,15 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load or create config: %s", err)
 	}
+
+	// If the API key is set in the env var, use it; we don't need to load the token.
+	if v := accesstoken.GetAPIKeyEnvVar(); v != "" {
+		return &Env{
+			Config:       c,
+			APIKeySecret: v,
+		}, nil
+	}
+
 	t, err := accesstoken.LoadToken(ctx, c)
 	if err != nil {
 		return nil, fmt.Errorf("load token: %s", err)
@@ -27,6 +36,15 @@ func NewEnv(ctx context.Context) (*Env, error) {
 
 // Env is a struct that contains the runtime env for the CLI.
 type Env struct {
-	Config *configs.C
-	Token  *accesstoken.T
+	Config       *configs.C
+	APIKeySecret string
+	Token        *accesstoken.T
+}
+
+// AccessToken returns the access token.
+func (e *Env) AccessToken() string {
+	if e.APIKeySecret != "" {
+		return e.APIKeySecret
+	}
+	return e.Token.AccessToken
 }


### PR DESCRIPTION
Set env var LLMARINER_API_KEY to use the API key for authorization instead of an access token generated with "llma auth login".

This is useful when we run the CLI commnads from integration test.