### PR TITLE
ci(pr-labeler): change trigger to pull_request_target

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: CI-pr-labeler
 on:
-  pull_request:
+  pull_request_target:
     types:
     - opened
     branches:


### PR DESCRIPTION
To grant write access for pull requests coming from forked repositories, modify the action trigger from `pull_request` to `pull_request_target`.