### PR TITLE
fix(provision): fix multi-cluster provision

### DIFF
--- a/deployments/llmariner/templates/secrets.yaml
+++ b/deployments/llmariner/templates/secrets.yaml
@@ -32,5 +32,5 @@ metadata:
     {{- include "llmariner.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{ .Values.global.worker.registrationKeySecret.key }}: {{ .Values.prepare.workerRegistration.secret.regKey | b64enc | quote }}
+  {{ .Values.global.worker.registrationKeySecret.key }}: {{ .Values.prepare.workerRegistration.secret.key | b64enc | quote }}
 {{- end }}

--- a/provision/dev/README.md
+++ b/provision/dev/README.md
@@ -28,11 +28,12 @@ helmfile apply --skip-diff-on-install
 
 ```bash
 ./create_cluster.sh multi
-helmfile apply -e control --skip-diff-on-install
+helmfile apply -e control -l app!=fake-gpu-operator --skip-diff-on-install
 
 # Please set the endpoint address to http://localhost/v1
 llma auth login
 export REGISTRATION_KEY=$(llma admin clusters register worker-cluster | sed -n 's/.*Registration Key: "\([^"]*\)".*/\1/p')
+helmfile apply -e worker -l app=fake-gpu-operator --skip-diff-on-install
 helmfile apply -e worker -l app=llmariner --skip-diff-on-install
 ```
 

--- a/provision/dev/README.md
+++ b/provision/dev/README.md
@@ -33,8 +33,7 @@ helmfile apply -e control -l app!=fake-gpu-operator --skip-diff-on-install
 # Please set the endpoint address to http://localhost/v1
 llma auth login
 export REGISTRATION_KEY=$(llma admin clusters register worker-cluster | sed -n 's/.*Registration Key: "\([^"]*\)".*/\1/p')
-helmfile apply -e worker -l app=fake-gpu-operator --skip-diff-on-install
-helmfile apply -e worker -l app=llmariner --skip-diff-on-install
+helmfile apply -e worker -l app=fake-gpu-operator -l app=llmariner --skip-diff-on-install
 ```
 
 > [!NOTE]

--- a/provision/dev/helmfile.yaml
+++ b/provision/dev/helmfile.yaml
@@ -87,6 +87,17 @@ releases:
     - {{ .Values.minio.adminPass }}
     - {{ .Values.minio.accessKey }}
     - {{ .Values.minio.secretKey }}
+    - {{ .Environment.KubeContext }}
+  {{ if eq .Environment.Name "control" }}
+  - events: ["postsync"]
+    showlogs: true
+    command: kubectl
+    args: ["--context={{.Environment.KubeContext}}", "apply", "-f", "minio_service.yaml"]
+  - events: ["postuninstall"]
+    showlogs: true
+    command: kubectl
+    args: ["--context={{.Environment.KubeContext}}", "delete", "-f", "minio_service.yaml"]
+  {{ end }}
 
 - name: milvus
   namespace: milvus
@@ -189,7 +200,7 @@ releases:
       value: {{ .Values.minio.bucket }}
   {{ if eq .Environment.Name "worker" }}
   hooks:
-  - events: ["presync"]
+  - events: ["postsync"]
     showlogs: true
     command: kubectl
     args: ["--context={{.Environment.KubeContext}}", "apply", "-f", "control_plane_service.yaml"]

--- a/provision/dev/minio_create_apikey.sh
+++ b/provision/dev/minio_create_apikey.sh
@@ -7,9 +7,10 @@ MINIO_USER=${1:?MINIO_USER}
 MINIO_PASS=${2:?MINIO_PASS}
 ACCESS_KEY=${3:?ACCESS_KEY}
 SECRET_KEY=${4:?SECRET_KEY}
+KUBECONFIG_CONTEXT=${5}
 
-kubectl wait --timeout=90s --for=condition=ready pod -n minio -l app.kubernetes.io/name=minio
-kubectl port-forward -n minio service/minio 9001 &
+kubectl wait --context "${KUBECONFIG_CONTEXT}" --timeout=90s --for=condition=ready pod -n minio -l app.kubernetes.io/name=minio
+kubectl port-forward --context "${KUBECONFIG_CONTEXT}" -n minio service/minio 9001 &
 sleep 5
 
 # Obtain the cookie and store in cookies.txt.

--- a/provision/dev/minio_service.yaml
+++ b/provision/dev/minio_service.yaml
@@ -1,0 +1,17 @@
+# To allow the worker-plane cluster to access MinIO.
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-nodeport
+  namespace: minio
+spec:
+  type: NodePort
+  ports:
+  - name: minio-api
+    port: 9000
+    protocol: TCP
+    targetPort: minio-api
+    nodePort: 31236
+  selector:
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/name: minio


### PR DESCRIPTION
- install fake GPU cluster in the worker-plane cluster
- create a NodePort service for MinIO so that the worker plane can access
- set the context to the contro-plane cluster when running minio_create_apikey.sh
- change 'presync' to 'postsync' for applying control_plane_service.yaml as the 'llmariner-wp' namespace needs to be created first
- fix the secret key