### PR TITLE
docs(provision): add a note on a helm diff error

### DIFF
--- a/provision/dev/README.md
+++ b/provision/dev/README.md
@@ -24,6 +24,11 @@ helmfile apply --skip-diff-on-install
 > For example, to filter out the monitoring components, set the `-l tier!=monitoring` flag.
 > For deploying just the llmariner, use `-l app=llmariner`.
 
+> [!NOTE]
+> If you run `helmfile` multiple times, you might get the follwing
+> error: `Error: unknown command "diff" for "helm"`. You can resolve the error
+> by installing [Helm Diff Plugin](https://github.com/databus23/helm-diff).
+
 ### Multi-Cluster Mode
 
 ```bash


### PR DESCRIPTION
When the initial helmfile installation fails for some reason, I need to retry and get an error due to the lack of Helm Diff Plugin.

Add a note for that.