### PR TITLE
feat(chart): bump versions

### DIFF
--- a/deployments/llmariner/Chart.yaml
+++ b/deployments/llmariner/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   tags:
   - control-plane
 - name: dex-server
-  version: 1.2.0
+  version: 1.3.0
   repository: "oci://public.ecr.aws/cloudnatix/llmariner-charts"
   tags:
   - control-plane
@@ -35,12 +35,12 @@ dependencies:
   tags:
   - control-plane
 - name: inference-manager-engine
-  version: 1.7.0
+  version: 1.8.0
   repository: "oci://public.ecr.aws/cloudnatix/llmariner-charts"
   tags:
   - worker
 - name: inference-manager-server
-  version: 1.7.0
+  version: 1.8.0
   repository: "oci://public.ecr.aws/cloudnatix/llmariner-charts"
   tags:
   - control-plane
@@ -65,7 +65,7 @@ dependencies:
   tags:
   - control-plane
 - name: rbac-server
-  version: 1.2.0
+  version: 1.3.0
   repository: "oci://public.ecr.aws/cloudnatix/llmariner-charts"
   tags:
   - control-plane
@@ -80,7 +80,7 @@ dependencies:
   tags:
   - control-plane
 - name: user-manager-server
-  version: 1.2.0
+  version: 1.4.0
   repository: "oci://public.ecr.aws/cloudnatix/llmariner-charts"
   tags:
   - control-plane

--- a/deployments/llmariner/Chart.yaml
+++ b/deployments/llmariner/Chart.yaml
@@ -80,7 +80,7 @@ dependencies:
   tags:
   - control-plane
 - name: user-manager-server
-  version: 1.4.0
+  version: 1.5.0
   repository: "oci://public.ecr.aws/cloudnatix/llmariner-charts"
   tags:
   - control-plane


### PR DESCRIPTION
- dex-server, rbac-server: 1.2.0 -> 1.3.0
- inference-manager-{engine,server}: 1.7.0 -> 1.8.0
- user-manager: 1.2.0 -> 1.4.0