### PR TITLE
fix(cli): make toAge() use the d format for less than one year case

### DIFF
--- a/cli/internal/time/age.go
+++ b/cli/internal/time/age.go
@@ -19,7 +19,7 @@ func toAge(t, now time.Time) string {
 		return fmt.Sprintf("%.0fh%dm", d.Hours(), min%60)
 	} else if d.Hours() < 24 {
 		return fmt.Sprintf("%.0fh", d.Hours())
-	} else if d.Hours() < 24*7 {
+	} else if d.Hours() < 24*365 {
 		return fmt.Sprintf("%.0fd", d.Hours()/24)
 	}
 	return fmt.Sprintf("%.0fy", d.Hours()/(24*365))

--- a/cli/internal/time/age_test.go
+++ b/cli/internal/time/age_test.go
@@ -38,6 +38,18 @@ func TestToAge(t *testing.T) {
 			t:    now.Add(-26 * time.Hour),
 			want: "1d",
 		},
+		{
+			t:    now.Add(-24 * 4 * time.Hour),
+			want: "4d",
+		},
+		{
+			t:    now.Add(-24 * 20 * time.Hour),
+			want: "20d",
+		},
+		{
+			t:    now.Add(-24 * 400 * time.Hour),
+			want: "1y",
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.t.String(), func(t *testing.T) {


### PR DESCRIPTION
Avoid "0y" when an age is > 7 days.