### PR TITLE
fix(helmfile): set --kube-context when provisioning multi-cluster

### DIFF
--- a/.github/workflows/manual-integration-test-multi-cluster.yaml
+++ b/.github/workflows/manual-integration-test-multi-cluster.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: deploy-control-plane
       uses: helmfile/helmfile-action@v1.9.3
       with:
-        helmfile-args: apply -e control -l app!=fake-gpu-operator,tier!=monitoring --skip-diff-on-install
+        helmfile-args: apply -e control -l app!=fake-gpu-operator,tier!=monitoring --skip-diff-on-install --kube-context kind-llmariner-control-plane
         helmfile-workdirectory: ./provision/dev/
     - name: wait-for-control-plane-readiness
       run: |
@@ -58,7 +58,7 @@ jobs:
     - name: deploy-worker-plane
       uses: helmfile/helmfile-action@v1.9.3
       with:
-        helmfile-args: apply -e worker -l app=llmariner -l app=fake-gpu-operator -l tier=monitoring --skip-diff-on-install
+        helmfile-args: apply -e worker -l app=llmariner -l app=fake-gpu-operator -l tier=monitoring --skip-diff-on-install --kube-context kind-llmariner-worker-plane
         helmfile-workdirectory: ./provision/dev/
     - name: wait-for-worker-plane-readiness
       run: |

--- a/provision/dev/README.md
+++ b/provision/dev/README.md
@@ -30,12 +30,11 @@ helmfile apply --skip-diff-on-install
 ```bash
 ./create_cluster.sh multi
 helmfile init
-helmfile apply -e control -l app!=fake-gpu-operator,tier!=monitoring --skip-diff-on-install
-
+helmfile apply -e control -l app!=fake-gpu-operator,tier!=monitoring --skip-diff-on-install --kube-context kind-llmariner-control-plane
 # Please set the endpoint address to http://localhost/v1
 llma auth login
 export REGISTRATION_KEY=$(llma admin clusters register worker-cluster | sed -n 's/.*Registration Key: "\([^"]*\)".*/\1/p')
-helmfile apply -e worker -l app=fake-gpu-operator -l tier=monitoring -l app=llmariner --skip-diff-on-install
+helmfile apply -e worker -l app=fake-gpu-operator -l tier=monitoring -l app=llmariner --skip-diff-on-install --kube-context kind-llmariner-worker-plane
 ```
 
 > [!NOTE]

--- a/provision/dev/helmfile.yaml
+++ b/provision/dev/helmfile.yaml
@@ -3,10 +3,8 @@ environments:
     values: [common.yaml]
   control:
     values: [common.yaml]
-    kubeContext: kind-llmariner-control-plane
   worker:
     values: [common.yaml]
-    kubeContext: kind-llmariner-worker-plane
 ---
 repositories:
 - name: kong


### PR DESCRIPTION
A suspect is that https://github.com/llmariner/llmariner/actions/runs/12778460659/job/35621565907 is failing with https://github.com/llmariner/llmariner/pull/606

Here is a log message. The 5-th argument (kubecontext) is empty.

```
in ./helmfile.yaml: failed processing release minio: hook[./minio_create_apikey.sh]: command `./minio_create_apikey.sh` failed: command "./minio_create_apikey.sh" exited with non-zero status: PATH:
  ./minio_create_apikey.sh
ARGS:
  0: ./minio_create_apikey.sh (24 bytes)
  1: minioadmin (10 bytes)
  2: minioadmin (10 bytes)
  3: llmariner-key (13 bytes)
  4: llmariner-secret (16 bytes)
  5:  (0 bytes)
  6: minio (5 bytes)
  
  ...

  error: no matching resources found
```