### PR TITLE
feat(chart): bump user-manager version

### DIFF
--- a/deployments/llmariner/Chart.yaml
+++ b/deployments/llmariner/Chart.yaml
@@ -99,7 +99,7 @@ dependencies:
   tags:
   - control-plane
 - name: user-manager-server
-  version: 1.9.0
+  version: 1.10.0
   repository: "oci://public.ecr.aws/cloudnatix/llmariner-charts"
   condition: user-manager-server.enable
   tags:

--- a/provision/dev/llmariner_values.yaml
+++ b/provision/dev/llmariner_values.yaml
@@ -200,10 +200,13 @@ session-manager-server:
 
 
 user-manager-server:
-  defaultApiKey:
-    name: default-key
+  defaultApiKeys:
+  - name: default-key
     secret: default-key-secret
     userId: admin@example.com
+  - name: default-service-account
+    secret: default-service-account-secret
+    isServiceAccount: true
   # To fit in a single node
   resources:
     limits:


### PR DESCRIPTION
Update llmariner_values.yaml for the new defaultApiKeys format.